### PR TITLE
Fix embedded cassandra startup

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ import com.twitter.sbt._
 object Build extends Build {
   
   val PhantomVersion = "1.12.2"
-  val CassandraUnitVersion = "2.1.3.2"
+  val CassandraUnitVersion = "2.1.9.2"
 
   val publishSettings: Seq[Def.Setting[_]] = Seq(
     publishMavenStyle := false,

--- a/src/main/scala/com/websudos/phantom/sbt/PhantomSbtPlugin.scala
+++ b/src/main/scala/com/websudos/phantom/sbt/PhantomSbtPlugin.scala
@@ -95,16 +95,17 @@ object EmbeddedCassandra {
     this.synchronized {
       if (!started) {
         blocking {
+          val configFile = config.map(_.toURI.toString) getOrElse EmbeddedCassandraServerHelper.DEFAULT_CASSANDRA_YML_FILE
+          System.setProperty("cassandra.config", configFile)
           try {
             EmbeddedCassandraServerHelper.mkdirs()
           } catch {
-            case NonFatal(e) => {
-              logger.error(e.getMessage)
-            }
+            case NonFatal(e) =>
+              logger.error(s"Error creating Embedded cassandra directories: ${e.getMessage}")
           }
           config match {
             case Some(file) =>
-              logger.info("Starting Cassandra in embedded mode with configuration from $file.")
+              logger.info(s"Starting Cassandra in embedded mode with configuration from $file.")
               EmbeddedCassandraServerHelper.startEmbeddedCassandra(file,
                 EmbeddedCassandraServerHelper.DEFAULT_TMP_DIR, EmbeddedCassandraServerHelper.DEFAULT_STARTUP_TIMEOUT)
             case None =>


### PR DESCRIPTION
Embedded cassandra startup fails with:

```
Expecting URI in variable: [cassandra.config].  Please prefix the file with file:/// for local files or file://<server>/ for remote files. Aborting. If you are executing this from an external tool, it needs to set Config.setClientMode(true) to avoid loading configuration.
```

This is due to Cassandra's `DatabaseDescriptor` trying to access the configuration file property in its static initializer.

We work around the problem by setting the property before startup.